### PR TITLE
Update actions/cache v3 -> v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Cache UV dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/uv


### PR DESCRIPTION
Found by an org-wide [actionlint](https://github.com/rhysd/actionlint) sweep. Per review feedback the lint tooling itself is staying in the core repos (compiler-explorer, infra, compiler-workflows) — this PR keeps just the fixes, which stand on their own:

- actions/cache v3 -> v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)